### PR TITLE
Rename bsc to spc across the project

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-BSC_CLUSTER_SIZE=5
+SPC_CLUSTER_SIZE=5
 CHAIN_ID=714
 KEYPASS="0123456789"
 INIT_HOLDER="0x04d63aBCd2b9b1baa327f2Dda0f873F197ccd186"
@@ -11,7 +11,7 @@ FullImmutabilityThreshold=2048
 MinBlocksForBlobRequests=576
 DefaultExtraReserveForBlobRequests=32
 BreatheBlockInterval=1200
-useLatestBscClient=false
+useLatestSpcClient=false
 EnableSentryNode=false
 EnableFullNode=false
 RegisterNodeID=false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deployment tools of BSC
+# Deployment tools of SPC
 
 
 ## Installation
@@ -43,35 +43,35 @@ go build
 5. Setup all nodes.
 two different ways, choose as you like.
 ```bash
-bash -x ./bsc_cluster.sh reset # will reset the cluster and start
-# The 'vidx' parameter is optional. If provided, its value must be in the range [0, ${BSC_CLUSTER_SIZE}). If omitted, it affects all clusters.
-bash -x ./bsc_cluster.sh stop [vidx] # Stops the cluster
-bash -x ./bsc_cluster.sh start [vidx] # only start the cluster
-bash -x ./bsc_cluster.sh restart [vidx] # start the cluster after stopping it
+bash -x ./spc_cluster.sh reset # will reset the cluster and start
+# The 'vidx' parameter is optional. If provided, its value must be in the range [0, ${SPC_CLUSTER_SIZE}). If omitted, it affects all clusters.
+bash -x ./spc_cluster.sh stop [vidx] # Stops the cluster
+bash -x ./spc_cluster.sh start [vidx] # only start the cluster
+bash -x ./spc_cluster.sh restart [vidx] # start the cluster after stopping it
 ```
 
 6. Setup a full node.
 If you want to run a full node to test snap/full syncing, you can run:
 
-> Attention: it relies on the validator cluster, so you should set up validators by `bsc_cluster.sh` firstly.
+> Attention: it relies on the validator cluster, so you should set up validators by `spc_cluster.sh` firstly.
 
 ```bash
 # start a full sync node0
-bash +x ./bsc_fullnode.sh start 0 full
+bash +x ./spc_fullnode.sh start 0 full
 # start a snap sync node1
-bash +x ./bsc_fullnode.sh start 1 snap
+bash +x ./spc_fullnode.sh start 1 snap
 # restart the snap sync node1
-bash +x ./bsc_fullnode.sh restart 1 snap
+bash +x ./spc_fullnode.sh restart 1 snap
 # stop the snap sync node1
-bash +x ./bsc_fullnode.sh stop 1 snap
+bash +x ./spc_fullnode.sh stop 1 snap
 # clean the snap sync node1
-bash +x ./bsc_fullnode.sh clean 1 snap
+bash +x ./spc_fullnode.sh clean 1 snap
 # start a snap sync node as fast node
-bash +x ./bsc_fullnode.sh start 2 snap "--tries-verify-mode none"
+bash +x ./spc_fullnode.sh start 2 snap "--tries-verify-mode none"
 # start a snap sync node with prune ancient
-bash +x ./bsc_fullnode.sh start 3 snap "--pruneancient"
+bash +x ./spc_fullnode.sh start 3 snap "--pruneancient"
 # start pruneblock for a node
-bash +x ./bsc_fullnode.sh pruneblock 3 snap
+bash +x ./spc_fullnode.sh pruneblock 3 snap
 ```
 
 You can see the logs in `.local/fullnode`.

--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,7 @@ WriteTimeout = 30000000000
 IdleTimeout = 120000000000
 
 [Node.LogConfig]
-FilePath = "bsc.log"
+FilePath = "spc.log"
 TimeFormat = "01-02|15:04:05.000"
 MaxBackups = 1000
 MaxBytesSize = 10485760

--- a/deploy_cluster.py
+++ b/deploy_cluster.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-BSC Cluster Deployment Script
-Deploys BSC nodes to multiple servers using Docker
+SPC Cluster Deployment Script
+Deploys SPC nodes to multiple servers using Docker
 """
 
 import os
@@ -24,7 +24,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-class BSCClusterDeployer:
+class SPCClusterDeployer:
     def __init__(self, config_path: str):
         self.config = self.load_config(config_path)
         self.distributor = FileDistributor(config_path)
@@ -267,7 +267,7 @@ class BSCClusterDeployer:
                 deployment_script = f"""#!/bin/bash
 set -e
 
-echo "Starting BSC validator node deployment on {server_name}"
+echo "Starting SPC validator node deployment on {server_name}"
 
 # Stop existing container if running
 docker stop {server_name} 2>/dev/null || true
@@ -276,7 +276,7 @@ docker rm {server_name} 2>/dev/null || true
 # Run Docker container
 {docker_cmd}
 
-echo "BSC validator node deployment completed on {server_name}"
+echo "SPC validator node deployment completed on {server_name}"
 
 # Wait for node to be ready for staking
 echo "Waiting for node to be ready for staking..."
@@ -303,7 +303,7 @@ echo "Validator registration and staking completed"
                 deployment_script = f"""#!/bin/bash
 set -e
 
-echo "Starting BSC {role} node deployment on {server_name}"
+echo "Starting SPC {role} node deployment on {server_name}"
 
 # Stop existing container if running
 docker stop {server_name} 2>/dev/null || true
@@ -323,7 +323,7 @@ fi
 # Run Docker container
 {docker_cmd}
 
-echo "BSC {role} node deployment completed on {server_name}"
+echo "SPC {role} node deployment completed on {server_name}"
 """
 
             # Upload and execute deployment script
@@ -518,7 +518,7 @@ echo "BSC {role} node deployment completed on {server_name}"
             return True
 
         try:
-            # Check if BSC_CLUSTER_SIZE in .env matches cluster.size in deployment config
+            # Check if SPC_CLUSTER_SIZE in .env matches cluster.size in deployment config
             cluster_size = self.config['cluster']['size']
             env_file_path = ".env"
             
@@ -527,19 +527,19 @@ echo "BSC {role} node deployment completed on {server_name}"
                 with open(env_file_path, 'r') as f:
                     env_content = f.read()
                 
-                # Extract BSC_CLUSTER_SIZE from .env
+                # Extract SPC_CLUSTER_SIZE from .env
                 import re
-                match = re.search(r'BSC_CLUSTER_SIZE=(\d+)', env_content)
+                match = re.search(r'SPC_CLUSTER_SIZE=(\d+)', env_content)
                 if match:
                     env_cluster_size = int(match.group(1))
                     
                     # If they don't match, update .env file
                     if env_cluster_size != cluster_size:
-                        logger.info(f"Updating BSC_CLUSTER_SIZE in .env from {env_cluster_size} to {cluster_size}")
-                        # Replace the BSC_CLUSTER_SIZE line
+                        logger.info(f"Updating SPC_CLUSTER_SIZE in .env from {env_cluster_size} to {cluster_size}")
+                        # Replace the SPC_CLUSTER_SIZE line
                         env_content = re.sub(
-                            r'BSC_CLUSTER_SIZE=\d+', 
-                            f'BSC_CLUSTER_SIZE={cluster_size}', 
+                            r'SPC_CLUSTER_SIZE=\d+',
+                            f'SPC_CLUSTER_SIZE={cluster_size}',
                             env_content
                         )
                         
@@ -548,16 +548,16 @@ echo "BSC {role} node deployment completed on {server_name}"
                             f.write(env_content)
                         logger.info(".env file updated successfully")
                 else:
-                    logger.warning("BSC_CLUSTER_SIZE not found in .env file")
+                    logger.warning("SPC_CLUSTER_SIZE not found in .env file")
             else:
                 logger.warning(".env file not found")
 
             if regenerate_genesis:
                 logger.info("Regenerating genesis.json and base config...")
 
-                # Call bsc_cluster.sh to regenerate genesis
+                # Call spc_cluster.sh to regenerate genesis
                 import subprocess
-                script_path = "./bsc_cluster.sh"
+                script_path = "./spc_cluster.sh"
             if not os.path.exists(script_path):
                 print(f"ERROR: Script not found at {script_path}")
             else:
@@ -663,7 +663,7 @@ fi
         return status
 
     def check_server_status(self, server_config: Dict[str, Any]) -> Dict[str, str]:
-        """Check status of BSC node on server"""
+        """Check status of SPC node on server"""
         try:
             ssh_client = self.create_ssh_client(server_config)
             container_name = server_config['name']
@@ -697,8 +697,8 @@ fi
             }
 
     def deploy_cluster(self) -> bool:
-        """Deploy BSC cluster to all servers"""
-        logger.info("Starting BSC cluster deployment")
+        """Deploy SPC cluster to all servers"""
+        logger.info("Starting SPC cluster deployment")
 
         # Build Docker image
         if not self.config['options'].get('skip_build', False):
@@ -755,7 +755,7 @@ fi
 
 
 def main():
-    parser = argparse.ArgumentParser(description="BSC Cluster Deployer")
+    parser = argparse.ArgumentParser(description="SPC Cluster Deployer")
     parser.add_argument("--config", default="deployment-config.yaml", help="Path to deployment config file")
     parser.add_argument("--action", choices=['deploy', 'monitor', 'files', 'add-node'], default='deploy', help="Action to perform")
     parser.add_argument("--server-name", help="Server name (from deployment-config.yaml) for add-node action")
@@ -775,7 +775,7 @@ def main():
         return 1
 
     try:
-        deployer = BSCClusterDeployer(args.config)
+        deployer = SPCClusterDeployer(args.config)
 
         # Override config options with command line args
         if args.skip_build:

--- a/deployment-config.yaml
+++ b/deployment-config.yaml
@@ -1,4 +1,4 @@
-# BSC Cluster Deployment Configuration
+# SPC Cluster Deployment Configuration
 deployment:
   name: "simple-chain"
   version: "1.0.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.8'
 
 services:
-  bsc-validator-1:
+  spc-validator-1:
     build: .
-    container_name: bsc-validator-1
+    container_name: spc-validator-1
     environment:
       - NODE_TYPE=validator
       - CONSENSUS_ADDRESS=0x${VALIDATOR_ADDRESS_1}
@@ -17,12 +17,12 @@ services:
       - "30303:30303"
       - "6060:6060"
     networks:
-      - bsc-network
+      - spc-network
     restart: unless-stopped
 
-  bsc-validator-2:
+  spc-validator-2:
     build: .
-    container_name: bsc-validator-2
+    container_name: spc-validator-2
     environment:
       - NODE_TYPE=validator
       - CONSENSUS_ADDRESS=0x${VALIDATOR_ADDRESS_2}
@@ -36,27 +36,27 @@ services:
       - "31303:30303"
       - "6160:6060"
     networks:
-      - bsc-network
+      - spc-network
     restart: unless-stopped
 
-  # bsc-fullnode:
+  # spc-fullnode:
   #   build: .
-  #   container_name: bsc-fullnode
+  #   container_name: spc-fullnode
   #   environment:
   #     - NODE_TYPE=fullnode
   #   volumes:
-  #     - ./deployment/fullnode:/home/bsc
-  #     - ./genesis/genesis.json:/home/bsc/genesis.json
-  #     - ./config.toml:/home/bsc/config.toml
+  #     - ./deployment/fullnode:/home/spc
+  #     - ./genesis/genesis.json:/home/spc/genesis.json
+  #     - ./config.toml:/home/spc/config.toml
   #   ports:
   #     - "8745:8545"
   #     - "8746:8546"
   #     - "32303:30303"
   #     - "6260:6060"
   #   networks:
-  #     - bsc-network
+  #     - spc-network
   #   restart: unless-stopped
 
 networks:
-  bsc-network:
+  spc-network:
     driver: bridge

--- a/file_distributor.py
+++ b/file_distributor.py
@@ -64,9 +64,9 @@ class FileDistributor:
         logger.info("Generating genesis.json and config files...")
 
         try:
-            # Call bsc_cluster.sh to generate genesis
+            # Call spc_cluster.sh to generate genesis
             import subprocess
-            result = subprocess.run(["bash", "bsc_cluster.sh"], capture_output=True, text=True)
+            result = subprocess.run(["bash", "spc_cluster.sh"], capture_output=True, text=True)
             if result.returncode != 0:
                 logger.error(f"Failed to generate genesis: {result.stderr}")
                 return False
@@ -641,7 +641,7 @@ class FileDistributor:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="BSC Node File Distributor")
+    parser = argparse.ArgumentParser(description="SPC Node File Distributor")
     parser.add_argument("--config", default="deployment-config.yaml", help="Path to deployment config file")
     parser.add_argument("--parallel", action="store_true", help="Enable parallel distribution")
     parser.add_argument("--max-parallel", type=int, default=5, help="Maximum parallel workers")

--- a/monitor_cluster.py
+++ b/monitor_cluster.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-BSC Cluster Monitor
-Monitors the status of BSC nodes in the cluster
+SPC Cluster Monitor
+Monitors the status of SPC nodes in the cluster
 """
 
 import os
@@ -21,7 +21,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-class BSCClusterMonitor:
+class SPCClusterMonitor:
     def __init__(self, config_path: str):
         self.config = self.load_config(config_path)
 
@@ -54,7 +54,7 @@ class BSCClusterMonitor:
             raise
 
     def check_server_status(self, server_config: Dict[str, Any]) -> Dict[str, Any]:
-        """Check status of BSC node on server"""
+        """Check status of SPC node on server"""
         server_name = server_config['name']
         server_host = server_config['host']
         http_port = server_config['ports']['http']
@@ -237,7 +237,7 @@ class BSCClusterMonitor:
     def print_status_report(self, cluster_status: Dict[str, Any]):
         """Print formatted status report"""
         print("\n" + "="*80)
-        print("BSC CLUSTER STATUS REPORT")
+        print("SPC CLUSTER STATUS REPORT")
         print("="*80)
         print(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(cluster_status['timestamp']))}")
         print(f"Cluster Size: {cluster_status['cluster_size']}")
@@ -299,7 +299,7 @@ class BSCClusterMonitor:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="BSC Cluster Monitor")
+    parser = argparse.ArgumentParser(description="SPC Cluster Monitor")
     parser.add_argument("--config", default="deployment-config.yaml", help="Path to deployment config file")
     parser.add_argument("--continuous", action="store_true", help="Enable continuous monitoring")
     parser.add_argument("--interval", type=int, default=60, help="Monitoring interval in seconds")
@@ -315,7 +315,7 @@ def main():
         return 1
 
     try:
-        monitor = BSCClusterMonitor(args.config)
+        monitor = SPCClusterMonitor(args.config)
 
         if args.continuous:
             monitor.start_continuous_monitoring(args.interval)

--- a/spc_cluster.sh
+++ b/spc_cluster.sh
@@ -9,7 +9,7 @@ basedir=$(
 )
 workspace=${basedir}
 source ${workspace}/.env
-size=$((BSC_CLUSTER_SIZE))
+size=$((SPC_CLUSTER_SIZE))
 stateScheme="hash"
 dbEngine="leveldb"
 gcmode="full"
@@ -55,13 +55,13 @@ function create_validator() {
     done
 }
 
-function prepare_bsc_client() {
-    if [ ${useLatestBscClient} = true ]; then
-        if [ ! -f "${workspace}/bsc/Makefile" ]; then
+function prepare_spc_client() {
+    if [ ${useLatestSpcClient} = true ]; then
+        if [ ! -f "${workspace}/spc/Makefile" ]; then
             cd ${workspace}
-            git clone https://github.com/bnb-chain/bsc.git
+            git clone https://github.com/bnb-chain/spc.git
         fi
-        cd ${workspace}/bsc && git pull && make geth && mv -f ${workspace}/bsc/build/bin/geth ${workspace}/bin/
+        cd ${workspace}/spc && git pull && make geth && mv -f ${workspace}/spc/build/bin/geth ${workspace}/bin/
     fi
 }
 # reset genesis, but keep edited genesis-template.json
@@ -137,8 +137,8 @@ function prepare_config() {
 
     cd ${workspace}/genesis/
     git checkout HEAD contracts
-    sed -i -e  's/alreadyInit = true;/turnLength = 16;alreadyInit = true;/' ${workspace}/genesis/contracts/BSCValidatorSet.sol
-    sed -i -e  's/public onlyCoinbase onlyZeroGasPrice {/public onlyCoinbase onlyZeroGasPrice {if (block.number < 300) return;/' ${workspace}/genesis/contracts/BSCValidatorSet.sol
+    sed -i -e  's/alreadyInit = true;/turnLength = 16;alreadyInit = true;/' ${workspace}/genesis/contracts/SPCValidatorSet.sol
+    sed -i -e  's/public onlyCoinbase onlyZeroGasPrice {/public onlyCoinbase onlyZeroGasPrice {if (block.number < 300) return;/' ${workspace}/genesis/contracts/SPCValidatorSet.sol
     
     poetry run python -m scripts.generate generate-validators
     poetry run python -m scripts.generate generate-init-holders "${initHolders}"
@@ -210,7 +210,7 @@ function initNetwork() {
         fi
     fi
     ${workspace}/bin/geth init-network --init.dir ${workspace}/.local --init.size=${size} --config ${workspace}/config.toml ${init_extra_args} ${workspace}/genesis/genesis.json
-    rm -f ${workspace}/*bsc.log*
+    rm -f ${workspace}/*spc.log*
     for ((i = 0; i < size; i++)); do
         sed -i -e '/"<nil>"/d' ${workspace}/.local/node${i}/config.toml
         # init genesis
@@ -222,13 +222,13 @@ function initNetwork() {
         else
             ${workspace}/bin/geth --datadir ${workspace}/.local/node${i} init --state.scheme path --db.engine pebble ${workspace}/genesis/genesis.json  > "${initLog}" 2>&1
         fi
-        rm -f ${workspace}/.local/node${i}/*bsc.log*
+        rm -f ${workspace}/.local/node${i}/*spc.log*
 
         if [ ${EnableSentryNode} = true ]; then
             sed -i -e '/"<nil>"/d' ${workspace}/.local/sentry${i}/config.toml
             initLog=${workspace}/.local/sentry${i}/init.log
             ${workspace}/bin/geth --datadir ${workspace}/.local/sentry${i} init --state.scheme path --db.engine pebble ${workspace}/genesis/genesis.json  > "${initLog}" 2>&1
-            rm -f ${workspace}/.local/sentry${i}/*bsc.log*
+            rm -f ${workspace}/.local/sentry${i}/*spc.log*
         fi
     done
     if [ ${EnableFullNode} = true ]; then
@@ -236,7 +236,7 @@ function initNetwork() {
         sed -i -e 's/EnableEVNFeatures = true/EnableEVNFeatures = false/g' ${workspace}/.local/fullnode0/config.toml
         initLog=${workspace}/.local/fullnode0/init.log
         ${workspace}/bin/geth --datadir ${workspace}/.local/fullnode0 init --state.scheme path --db.engine pebble ${workspace}/genesis/genesis.json  > "${initLog}" 2>&1
-        rm -f ${workspace}/.local/fullnode0/*bsc.log*
+        rm -f ${workspace}/.local/fullnode0/*spc.log*
     fi
 }
 
@@ -264,7 +264,7 @@ function native_start() {
         cp ${workspace}/bin/geth ${workspace}/.local/node${i}/geth${i}
         # update `config` in genesis.json
         # ${workspace}/.local/node${i}/geth${i} dumpgenesis --datadir ${workspace}/.local/node${i} | jq . > ${workspace}/.local/node${i}/genesis.json
-        # run BSC node
+        # run SPC node
         nohup  ${workspace}/.local/node${i}/geth${i} --config ${workspace}/.local/node${i}/config.toml \
             --mine --vote --password ${workspace}/.local/node${i}/password.txt --unlock ${cons_addr} --miner.etherbase ${cons_addr} --blspassword ${workspace}/.local/node${i}/password.txt \
             --datadir ${workspace}/.local/node${i} \
@@ -277,7 +277,7 @@ function native_start() {
             --override.passedforktime ${PassedForkTime} --override.lorentz ${PassedForkTime} --override.maxwell ${LastHardforkTime} \
             --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
             --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
-            >> ${workspace}/.local/node${i}/bsc-node.log 2>&1 &
+            >> ${workspace}/.local/node${i}/spc-node.log 2>&1 &
         
         if [ ${EnableSentryNode} = true ]; then
             cp ${workspace}/bin/geth ${workspace}/.local/sentry${i}/geth${i}
@@ -292,7 +292,7 @@ function native_start() {
                 --override.passedforktime ${PassedForkTime} --override.lorentz ${PassedForkTime} --override.maxwell ${LastHardforkTime} \
                 --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
                 --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
-                >> ${workspace}/.local/sentry${i}/bsc-node.log 2>&1 &
+                >> ${workspace}/.local/sentry${i}/spc-node.log 2>&1 &
         fi
     done
 
@@ -308,7 +308,7 @@ function native_start() {
             --gcmode ${gcmode} --syncmode full --monitor.maliciousvote \
             --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
             --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
-            >> ${workspace}/.local/fullnode0/bsc-node.log 2>&1 &
+            >> ${workspace}/.local/fullnode0/spc-node.log 2>&1 &
     fi
     sleep ${sleepAfterStart}
 }
@@ -331,7 +331,7 @@ case ${CMD} in
 reset)
     exit_previous
     create_validator
-    prepare_bsc_client
+    prepare_spc_client
     reset_genesis
     prepare_config
     initNetwork
@@ -354,6 +354,6 @@ regen-genesis)
     prepare_config
     ;;
 *)
-    echo "Usage: bsc_cluster.sh | reset | stop [vidx]| start [vidx]| restart [vidx] | regen-genesis"
+    echo "Usage: spc_cluster.sh | reset | stop [vidx]| start [vidx]| restart [vidx] | regen-genesis"
     ;;
 esac

--- a/spc_fullnode.sh
+++ b/spc_fullnode.sh
@@ -55,7 +55,7 @@ function start() {
   --rialtohash ${rialtoHash} --override.passedforktime ${PassedForkTime} --override.lorentz ${PassedForkTime} --override.maxwell ${LastHardforkTime} \
   --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
   --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
-  > $dst/bsc-node.log 2>&1 &
+  > $dst/spc-node.log 2>&1 &
   echo $! > $dst/pid
 }
 
@@ -110,7 +110,7 @@ pruneblock)
     echo "===== end ===="
     ;;
 *)
-    echo "Usage: bsc_fullnode.sh start|stop|restart|clean nodeIndex syncmode"
-    echo "like: bsc_fullnode.sh start 1 snap, it will startup a snapsync node1"
+    echo "Usage: spc_fullnode.sh start|stop|restart|clean nodeIndex syncmode"
+    echo "like: spc_fullnode.sh start 1 snap, it will startup a snapsync node1"
     ;;
 esac


### PR DESCRIPTION
## Summary
- Rename all `bsc` naming to `spc` across the entire project
- Rename shell scripts: `bsc_cluster.sh` → `spc_cluster.sh`, `bsc_fullnode.sh` → `spc_fullnode.sh`
- Update environment variables: `BSC_CLUSTER_SIZE` → `SPC_CLUSTER_SIZE`, `useLatestBscClient` → `useLatestSpcClient`
- Update Docker Compose service/container/network names
- Update Python class names: `BSCClusterDeployer` → `SPCClusterDeployer`, `BSCClusterMonitor` → `SPCClusterMonitor`
- Update all log file paths, script references, README, and config file entries

## Verification
- Shell scripts pass `bash -n` syntax check
- Python files pass syntax check (pre-existing syntax issue in `monitor_cluster.py` is unrelated)
- No Go files were touched (only exact `bsc` word matches, not substrings like `Subscription`)
- Zero remaining `bsc` references in project source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)